### PR TITLE
Updating readme to add flathub download 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@
 
 5. **Manage Remotes:** 📦 Installed and enabled Flatpak remotes can be deleted, and new remotes can be added.
 
-## 🛠️ Download
-
-<a href="https://flathub.org/apps/io.github.flattool.Warehouse" align="center">
-  <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
-</a>
-
 ![Various screenshots of Warehouse's abilities](screenshots.png)
 
 ## 💬 Get in Contact
@@ -36,3 +30,9 @@
 To use Warehouse effectively, ensure the following dependencies are installed on your system:
 - GIO
 - GNOME Flatpak Runtime and SDK version 45
+
+## 🛠️ Download
+
+<a href="https://flathub.org/apps/io.github.flattool.Warehouse" align="center">
+  <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
+</a>

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 - You can always open issues, PRs, and use other GitHub features here
 
 ## ℹ️ Important Notes:
-- Translators, I thank you very much for your interest and contributions, but as of now Warehouse is not accpeting any translation work until proper translation infrastructure is in place.
+- Translators, I thank you very much for your interest and contributions, but as of now Warehouse is not accepting any translation work until proper translation infrastructure is in place.
 - This project is still in its early stages, developed by a newcomer. Your understanding of potential bugs is greatly appreciated.
 - Warehouse assumes flatpak user data is located in the default directory: `~/.var/app`.
 - Warehouse does not aim to replace flatpak; it simply facilitates appropriate flatpak commands for the desired actions.
-- 
+
 ## 🛠️ Download
 
 <a href="https://flathub.org/apps/io.github.flattool.Warehouse" align="center">

--- a/README.md
+++ b/README.md
@@ -25,14 +25,19 @@
 - This project is still in its early stages, developed by a newcomer. Your understanding of potential bugs is greatly appreciated.
 - Warehouse assumes flatpak user data is located in the default directory: `~/.var/app`.
 - Warehouse does not aim to replace flatpak; it simply facilitates appropriate flatpak commands for the desired actions.
-
-## 📦 Dependencies:
-To use Warehouse effectively, ensure the following dependencies are installed on your system:
-- GIO
-- GNOME Flatpak Runtime and SDK version 45
-
+- 
 ## 🛠️ Download
 
 <a href="https://flathub.org/apps/io.github.flattool.Warehouse" align="center">
   <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
 </a>
+
+The recommended way of installing Warehouse is through Flatpak. If you don't have
+Flatpak installed, you can get it from [the Flatpak website](https://flatpak.org/setup).
+
+You can install stable builds of Warehouse from [Flathub](https://flathub.org)
+by using this commands:
+   ```shell
+    flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    flatpak install flathub io.github.flattool.Warehouse
+   ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
   <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
 </a>
 
-
 The recommended way of installing Warehouse is through Flatpak. If you don't have
 Flatpak installed, you can get it from [the Flatpak website](https://flatpak.org/setup).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
 </a>
 
+
 The recommended way of installing Warehouse is through Flatpak. If you don't have
 Flatpak installed, you can get it from [the Flatpak website](https://flatpak.org/setup).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 
 5. **Manage Remotes:** 📦 Installed and enabled Flatpak remotes can be deleted, and new remotes can be added.
 
+## 🛠️ Download
+
+<a href="https://flathub.org/apps/io.github.flattool.Warehouse" align="center">
+  <img width="200" src="https://flathub.org/assets/badges/flathub-badge-i-en.png">
+</a>
+
 ![Various screenshots of Warehouse's abilities](screenshots.png)
 
 ## 💬 Get in Contact
@@ -30,15 +36,3 @@
 To use Warehouse effectively, ensure the following dependencies are installed on your system:
 - GIO
 - GNOME Flatpak Runtime and SDK version 45
-
-## 🛠️ Installation Steps:
-1. Make sure you have the above dependencies installed.
-2. Visit the [releases](https://github.com/flattool/warehouse/releases) page and download `io.github.flattool.Warehouse.flatpak`.
-3. Install it using your software store or run the following command:
-   ```shell
-   $ flatpak install /path/to/io.github.flattool.Warehouse.flatpak
-   ```
-You're all set! Launch the application by clicking its icon in your app menu or running:
-```shell
-$ flatpak run io.github.flattool.Warehouse
-```


### PR DESCRIPTION
Just added the flathub image, some updated commands (that basically make you install it from flathub) so the manual download and installation steps are not a thing anymore.

Also removed dependencies list since I don't think they are really necessary anymore.