### PR TITLE
Fix build warning

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -25,7 +25,7 @@ gnome.compile_resources('warehouse',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
This fixes the deprecation warning:

```
WARNING: Deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
```