### PR TITLE
Remove context from shortcuts window

### DIFF
--- a/src/gtk/help-overlay.blp
+++ b/src/gtk/help-overlay.blp
@@ -8,61 +8,61 @@ ShortcutsWindow help_overlay {
     // max-height: 8;
 
     ShortcutsGroup {
-      title: C_("shortcut window", "App Management");
+      title: _("App Management");
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Search");
+        title: _("Search");
         action-name: "app.search";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Set a Filter");
+        title: _("Set a Filter");
         action-name: "app.set-filter";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Refresh");
+        title: _("Refresh");
         action-name: "app.refresh-list";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Toggle Selection Mode");
+        title: _("Toggle Selection Mode");
         action-name: "app.toggle-batch-mode";
       }
     }
     ShortcutsGroup {
-      title: C_("shortcut window", "More Functions");
+      title: _("More Functions");
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Manage Leftover Data");
+        title: _("Manage Leftover Data");
         action-name: "app.manage-data-folders";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Manage Remotes");
+        title: _("Manage Remotes");
         action-name: "app.show-remotes-window";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Install From File");
+        title: _("Install From File");
         action-name: "app.install-from-file";
       }
     }
     ShortcutsGroup {
-      title: C_("shortcut window", "General");
+      title: _("General");
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Open Menu");
+        title: _("Open Menu");
         action-name: "app.open-menu";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Show Shortcuts");
+        title: _("Show Shortcuts");
         action-name: "win.show-help-overlay";
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Quit");
+        title: _("Quit");
         action-name: "app.quit";
       }
     }


### PR DESCRIPTION
This is to avoid duplicate translatable strings where they don't actually need to be separated.