### PR TITLE
Untested: (Pages) Fix Flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Warehouse is now available on Flathub! Visit your software store and search for Warehouse, or click this badge.
 
-<a href=https://flathub.org/apps/io.github.flattool.Warehouse><img width='240' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=en'/></a>
+<a href="https://flathub.org/apps/io.github.flattool.Warehouse"><img width='240' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=en'/></a>
 
 ## 🗣️ Translation
 - Translation is hosted with Weblate on Fyra Labs, [click here](https://weblate.fyralabs.com/projects/flattool/warehouse/) to contribute


### PR DESCRIPTION
The "Get it on Flathub" badge is not rendered correctly on the deployed GitHub page.
I suspect this happens because the `<a>` tag is missing quotes on the `href` attribute. \
However I can't say for sure since I can't deploy it directly.