### PR TITLE
Sort runtime filter list

### DIFF
--- a/src/host_info.py
+++ b/src/host_info.py
@@ -382,6 +382,9 @@ class HostInfo:
 					if not runtime in this.dependent_runtime_refs:
 						this.dependent_runtime_refs.append(runtime)
 
+				# store runtimes in sorted order
+				this.dependent_runtime_refs = sorted(this.dependent_runtime_refs)
+
 			except subprocess.CalledProcessError as cpe:
 				this.main_window.toast_overlay.add_toast(ErrorToast(_("Could not load packages"), cpe.stderr).toast)
 			except Exception as e:


### PR DESCRIPTION
It was implemented before in #84, but was lost in the 2.0 rewrite.

**Before:**
![before](https://github.com/user-attachments/assets/c418ec5d-1636-4d41-add5-c6cd3d5abccc)

**After:**
![after](https://github.com/user-attachments/assets/5e1c0bd2-704b-4268-87d4-848a74de0fe4)
